### PR TITLE
Quick fix for the tile background prefab

### DIFF
--- a/Assets/Prefabs/Tile Background.prefab
+++ b/Assets/Prefabs/Tile Background.prefab
@@ -73,7 +73,7 @@ SpriteRenderer:
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
   m_SortingLayer: 0
-  m_SortingOrder: 0
+  m_SortingOrder: -1
   m_Sprite: {fileID: 21300000, guid: 86ecbab3e895e467db12434659a247a6, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0


### PR DESCRIPTION
The dots were appearing darker than intended, and it was because of the layering order with the dots and the tile background.